### PR TITLE
Update calculate_accuracies.py to handle model names more gracefully

### DIFF
--- a/src/calculate_accuracies.py
+++ b/src/calculate_accuracies.py
@@ -98,7 +98,7 @@ def calculate_accuracy(task,mmlu,filename,closed_flag, keep_idxs=None):
 
 def main(pred_files, shot, output_dir,closed_flag):
     os.makedirs(output_dir, exist_ok=True)
-    mmlu = pd.read_json(f'/workspace/MalayMMLU/data/MalayMMLU_{shot}shot.json')
+    mmlu = pd.read_json(f'data/MalayMMLU_{shot}shot.json')
     print("loaded data")
     
     

--- a/src/calculate_accuracies.py
+++ b/src/calculate_accuracies.py
@@ -24,8 +24,14 @@ def calculate_accuracy(task,mmlu,filename,closed_flag, keep_idxs=None):
                 
                 result = pd.read_csv(filename)
                 
-                split = filename.split("_") 
-                by_letter = split[3]
+                # Fixed filename parsing logic
+                base_filename = os.path.basename(filename)
+                # For filename with hyphens, like: MalayMMLU_result_Malaysian-Qwen2.5-14B-Reasoning-SFT_False_0shot.csv
+                # We need to find the last two underscores to get by_letter and shot info
+                parts = base_filename.split("_")
+                by_letter = parts[-2]  # "False" part of the evaluation file name generated from evaluation
+                shot_part = parts[-1].replace(".csv", "")  # "0shot"
+                
                 if by_letter == "True":
             
                     correct_org = 0
@@ -66,9 +72,11 @@ def calculate_accuracy(task,mmlu,filename,closed_flag, keep_idxs=None):
                 
                 result = pd.read_csv(filename)
                 
-                split = filename.split("_") 
-                by_letter = split[3]
-            
+                # Fixed filename parsing logic
+                base_filename = os.path.basename(filename)
+                parts = base_filename.split("_")
+                by_letter = parts[-2]  # "False"
+                
                 if by_letter == "True":
             
                     correct_org = 0
@@ -90,7 +98,7 @@ def calculate_accuracy(task,mmlu,filename,closed_flag, keep_idxs=None):
 
 def main(pred_files, shot, output_dir,closed_flag):
     os.makedirs(output_dir, exist_ok=True)
-    mmlu = pd.read_json(f'data/MalayMMLU_{shot}shot.json')
+    mmlu = pd.read_json(f'/workspace/MalayMMLU/data/MalayMMLU_{shot}shot.json')
     print("loaded data")
     
     
@@ -109,9 +117,14 @@ def main(pred_files, shot, output_dir,closed_flag):
 
             if closed_flag: 
                 first_acc, full_acc = calculate_accuracy("MalayMMLU", mmlu, pred_file_str, closed_flag, keep_ids)
-                split = pred_file_str.split("_")
-                models += [split[1], split[1]]
-                shots += [split[2].split(".")[0], split[2].split(".")[0]]
+                # Fixed filename parsing
+                base_filename = os.path.basename(pred_file_str)
+                parts = base_filename.split("_")
+                # Extract model name (everything between "result_" and the last two parts)
+                model_name = "_".join(parts[2:-2])
+                
+                models += [model_name, model_name]
+                shots += [parts[-1].replace(".csv", ""), parts[-1].replace(".csv", "")]
                 by_letter += ["True", "False"]
                 org_accs += [first_acc, full_acc]
 
@@ -120,10 +133,15 @@ def main(pred_files, shot, output_dir,closed_flag):
                 org_acc = calculate_accuracy("MalayMMLU", mmlu, pred_file_str,  closed_flag, keep_ids)
                 org_accs.append(org_acc)
                 
-                split = pred_file_str.split("_")
-                models.append(split[2])
-                by_letter.append(split[3])
-                shots.append(split[4].split(".")[0])
+                # Fixed filename parsing
+                base_filename = os.path.basename(pred_file_str)
+                parts = base_filename.split("_")
+                # Extract model name (everything between "result_" and the last two parts)
+                model_name = "_".join(parts[2:-2])
+                
+                models.append(model_name)
+                by_letter.append(parts[-2])  # "False"
+                shots.append(parts[-1].replace(".csv", ""))  # "0shot"
                 categories += [cat]
 
 
@@ -189,7 +207,7 @@ def main(pred_files, shot, output_dir,closed_flag):
 
             for category in category2amount.keys():
                 category_df = df[df.category == category]
-                if not category_df.empty:
+                if not category_df.empty and category_df.iloc[0]['Accuracy'] is not None:
                     sum_acc += category2amount[category] * category_df.iloc[0]['Accuracy'] 
             average_acc = sum_acc / len(mmlu)
 
@@ -232,4 +250,3 @@ if __name__ == "__main__":
 
     else:
         main(args.pred_files, args.shot, args.output_dir, args.closed)
-


### PR DESCRIPTION
I noticed that the accuracy calculation logic, to determine if it's 'First Token Accuracy' or 'Full Answer Probability', you split the filename into chunks using the '.split()' method, and take the 4th element (split[3]) to help determine the type of benchmark to be used to calculate the accuracy numbers.

This causes problems when the model name contains hyphens (e.g. 'MalayMMLU_result_Malaysian-Qwen2.5-14B-Reasoning-SFT_False_0shot'), which when split by underscore creates more parts than the original code expected, hence causing this error where nothing is being calculated just because of the file name:
```
loaded data
              Model Accuracy             shot by_letter        category
0  qwen2R/MalayMMLU     None  Malaysian-Qwen2    result            STEM
1  qwen2R/MalayMMLU     None  Malaysian-Qwen2    result        Language
2  qwen2R/MalayMMLU     None  Malaysian-Qwen2    result  Social science
3  qwen2R/MalayMMLU     None  Malaysian-Qwen2    result          Others
4  qwen2R/MalayMMLU     None  Malaysian-Qwen2    result      Humanities
{'Social science': np.int64(6918), 'Language': np.int64(6288), 'Humanities': np.int64(4395), 'Others': np.int64(4169), 'STEM': np.int64(2443)}
Traceback (most recent call last):
  File "/workspace/MalayMMLU/src/calculate_accuracies.py", line 234, in <module>
    main(args.pred_files, args.shot, args.output_dir, args.closed)
  File "/workspace/MalayMMLU/src/calculate_accuracies.py", line 193, in main
    sum_acc += category2amount[category] * category_df.iloc[0]['Accuracy'] 
               ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'
```

Edited calculate_accuracies.py to instead use `parts[-2]` to get the second-to-last part after splitting by underscore. This also fixes model name extraction: Instead of using `split[2]`, I now use `"_".join(parts[2:-2])` to properly handle model names with hyphens. Also added a `None` check before multiplication to prevent the TypeError.

After the fixed was applied, now calculations are done correctly:
```
loaded data
                                 Model   Accuracy  ... by_letter        category
0  Malaysian-Qwen2.5-14B-Reasoning-SFT  70.118707  ...     False            STEM
1  Malaysian-Qwen2.5-14B-Reasoning-SFT  72.328244  ...     False        Language
2  Malaysian-Qwen2.5-14B-Reasoning-SFT  63.428737  ...     False  Social science
3  Malaysian-Qwen2.5-14B-Reasoning-SFT  63.996162  ...     False          Others
4  Malaysian-Qwen2.5-14B-Reasoning-SFT  69.692833  ...     False      Humanities

[5 rows x 5 columns]
{'Social science': np.int64(6918), 'Language': np.int64(6288), 'Humanities': np.int64(4395), 'Others': np.int64(4169), 'STEM': np.int64(2443)}
Model : Malaysian-Qwen2.5-14B-Reasoning-SFT
Metric : full
Shot : 0shot
average accuracy 67.64960971379011
accuracy for STEM 70.11870650839133
accuracy for Language 72.32824427480917
accuracy for Social science 63.428736629083545
accuracy for Others 63.996162149196444
accuracy for Humanities 69.69283276450511
```